### PR TITLE
Add service-sector goods definitions

### DIFF
--- a/mod/common/goods/10_service_goods.txt
+++ b/mod/common/goods/10_service_goods.txt
@@ -1,0 +1,52 @@
+# Service sector expansion goods definitions
+# Added for mod as described in Goals.md
+
+beer = {
+    texture = "gfx/interface/icons/goods_icons/beer.dds"
+    cost = 20
+    category = consumer
+    obsession_chance = 2.0
+    prestige_factor = 4
+    traded_quantity = 8 # 240
+    convoy_cost_multiplier = 0.75
+}
+
+service_beer = {
+    texture = "gfx/interface/icons/goods_icons/service_beer.dds"
+    cost = 30
+    category = service
+    local = yes
+    consumption_tax_cost = 200
+}
+
+service_liquor = {
+    texture = "gfx/interface/icons/goods_icons/service_liquor.dds"
+    cost = 30
+    category = service
+    local = yes
+    consumption_tax_cost = 200
+}
+
+service_food = {
+    texture = "gfx/interface/icons/goods_icons/service_food.dds"
+    cost = 30
+    category = service
+    local = yes
+    consumption_tax_cost = 200
+}
+
+service_coffee = {
+    texture = "gfx/interface/icons/goods_icons/service_coffee.dds"
+    cost = 30
+    category = service
+    local = yes
+    consumption_tax_cost = 200
+}
+
+service_tobacco = {
+    texture = "gfx/interface/icons/goods_icons/service_tobacco.dds"
+    cost = 30
+    category = service
+    local = yes
+    consumption_tax_cost = 200
+}

--- a/mod/localization/english/goods_l_english.yml
+++ b/mod/localization/english/goods_l_english.yml
@@ -1,0 +1,7 @@
+l_english:
+ beer:0 "Beer"
+ service_beer:0 "Beer Service"
+ service_liquor:0 "Liquor Service"
+ service_food:0 "Prepared Meals"
+ service_coffee:0 "Coffee Service"
+ service_tobacco:0 "Tobacco Service"


### PR DESCRIPTION
## Summary
- add beer and various service goods definitions to `mod/common/goods`
- add English localisation for new goods

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ef3862d68832ebefccc6c7ec874b2