### PR TITLE
Add hospitality workforce mix

### DIFF
--- a/common/building_groups/99_hospitality.txt
+++ b/common/building_groups/99_hospitality.txt
@@ -1,0 +1,10 @@
+# Hospitality buildings providing services
+bg_hospitality = {
+    parent_group = bg_service
+    category = urban
+    lens = development
+    economy_of_scale = yes
+    cash_reserves_max = 25000
+    urbanization = 10
+    infrastructure_usage_per_level = 1
+}

--- a/common/buildings/99_hospitality.txt
+++ b/common/buildings/99_hospitality.txt
@@ -1,0 +1,52 @@
+# Hospitality buildings
+building_bar = {
+    building_group = bg_hospitality
+    icon = "gfx/interface/icons/building_icons/bar.dds"
+    city_type = city
+    levels_per_mesh = 5
+    production_method_groups = {
+        pmg_base_building_bar
+    }
+    required_construction = construction_cost_low
+    ownership_type = self
+    background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_monuments.dds"
+}
+
+building_restaurant = {
+    building_group = bg_hospitality
+    icon = "gfx/interface/icons/building_icons/restaurant.dds"
+    city_type = city
+    levels_per_mesh = 5
+    production_method_groups = {
+        pmg_base_building_restaurant
+    }
+    required_construction = construction_cost_medium
+    ownership_type = self
+    background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_monuments.dds"
+}
+
+building_cafe = {
+    building_group = bg_hospitality
+    icon = "gfx/interface/icons/building_icons/cafe.dds"
+    city_type = city
+    levels_per_mesh = 5
+    production_method_groups = {
+        pmg_base_building_cafe
+    }
+    required_construction = construction_cost_low
+    ownership_type = self
+    background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_monuments.dds"
+}
+
+building_dispensary = {
+    building_group = bg_hospitality
+    icon = "gfx/interface/icons/building_icons/dispensary.dds"
+    city_type = city
+    levels_per_mesh = 5
+    production_method_groups = {
+        pmg_base_building_dispensary
+    }
+    required_construction = construction_cost_low
+    ownership_type = self
+    background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_monuments.dds"
+}

--- a/common/goods/00_service_goods.txt
+++ b/common/goods/00_service_goods.txt
@@ -1,0 +1,38 @@
+# New service and consumer goods
+beer = {
+    texture = "gfx/interface/icons/goods_icons/beer.dds"
+    cost = 20
+    category = luxury
+    obsession_chance = 1.0
+    prestige_factor = 4
+}
+service_beer = {
+    texture = "gfx/interface/icons/goods_icons/service_beer.dds"
+    cost = 25
+    category = luxury
+    local = yes
+}
+service_liquor = {
+    texture = "gfx/interface/icons/goods_icons/service_liquor.dds"
+    cost = 30
+    category = luxury
+    local = yes
+}
+service_food = {
+    texture = "gfx/interface/icons/goods_icons/service_food.dds"
+    cost = 25
+    category = luxury
+    local = yes
+}
+service_coffee = {
+    texture = "gfx/interface/icons/goods_icons/service_coffee.dds"
+    cost = 35
+    category = luxury
+    local = yes
+}
+service_tobacco = {
+    texture = "gfx/interface/icons/goods_icons/service_tobacco.dds"
+    cost = 30
+    category = luxury
+    local = yes
+}

--- a/common/pop_types/manager.txt
+++ b/common/pop_types/manager.txt
@@ -1,0 +1,15 @@
+manager = {
+    texture = "gfx/interface/icons/pops_icons/manager.dds"
+    color = hsv{ 0.28 0.45 0.80 }
+    unemployment = yes
+    wage_weight = 1.4
+    paid_private_wage = yes
+    literacy_target = 0.25
+    education_access = 0.25
+    political_engagement_base = 0.3
+    political_engagement_literacy_factor = 0.6
+    start_quality_of_life = 8
+    dependent_wage = 0.5
+    unemployment_wealth = 8
+    portrait_pose = { value = 1 }
+}

--- a/common/pop_types/service_worker.txt
+++ b/common/pop_types/service_worker.txt
@@ -1,0 +1,14 @@
+service_worker = {
+    texture = "gfx/interface/icons/pops_icons/service_worker.dds"
+    color = hsv{ 0.15 0.40 0.70 }
+    unemployment = yes
+    wage_weight = 1.2
+    paid_private_wage = yes
+    literacy_target = 0.10
+    political_engagement_base = 0.2
+    political_engagement_literacy_factor = 0.6
+    start_quality_of_life = 6
+    dependent_wage = 0.5
+    unemployment_wealth = 6
+    portrait_pose = { value = 0 }
+}

--- a/common/production_method_groups/99_hospitality.txt
+++ b/common/production_method_groups/99_hospitality.txt
@@ -1,0 +1,30 @@
+pmg_base_building_bar = {
+    texture = "gfx/interface/icons/generic_icons/mixed_icon_base.dds"
+    production_methods = {
+        pm_bar_beer
+        pm_bar_liquor
+    }
+}
+
+pmg_base_building_restaurant = {
+    texture = "gfx/interface/icons/generic_icons/mixed_icon_base.dds"
+    production_methods = {
+        pm_restaurant_meat
+        pm_restaurant_groceries
+    }
+}
+
+pmg_base_building_cafe = {
+    texture = "gfx/interface/icons/generic_icons/mixed_icon_base.dds"
+    production_methods = {
+        pm_cafe_coffee
+        pm_cafe_tea
+    }
+}
+
+pmg_base_building_dispensary = {
+    texture = "gfx/interface/icons/generic_icons/mixed_icon_base.dds"
+    production_methods = {
+        pm_dispensary_tobacco
+    }
+}

--- a/common/production_methods/99_hospitality.txt
+++ b/common/production_methods/99_hospitality.txt
@@ -1,0 +1,85 @@
+pm_bar_beer = {
+    texture = "gfx/interface/icons/production_method_icons/bar_beer.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_beer_add = 10 goods_output_service_beer_add = 8 }
+        level_scaled = {
+            building_employment_service_workers_add = 4500
+            building_employment_managers_add = 450
+            building_employment_capitalists_add = 50
+        }
+    }
+}
+
+pm_bar_liquor = {
+    texture = "gfx/interface/icons/production_method_icons/bar_liquor.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_liquor_add = 10 goods_output_service_liquor_add = 8 }
+        level_scaled = {
+            building_employment_service_workers_add = 4500
+            building_employment_managers_add = 450
+            building_employment_capitalists_add = 50
+        }
+    }
+}
+
+pm_restaurant_meat = {
+    texture = "gfx/interface/icons/production_method_icons/restaurant_meat.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_meat_add = 10 goods_output_service_food_add = 8 }
+        level_scaled = {
+            building_employment_service_workers_add = 4250
+            building_employment_managers_add = 700
+            building_employment_capitalists_add = 50
+        }
+    }
+}
+
+pm_restaurant_groceries = {
+    texture = "gfx/interface/icons/production_method_icons/restaurant_groceries.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_groceries_add = 10 goods_output_service_food_add = 10 }
+        level_scaled = {
+            building_employment_service_workers_add = 4250
+            building_employment_managers_add = 700
+            building_employment_capitalists_add = 50
+        }
+    }
+    unlocking_technologies = { canning }
+}
+
+pm_cafe_coffee = {
+    texture = "gfx/interface/icons/production_method_icons/cafe_coffee.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_coffee_add = 8 goods_output_service_coffee_add = 6 }
+        level_scaled = {
+            building_employment_service_workers_add = 4400
+            building_employment_managers_add = 550
+            building_employment_capitalists_add = 50
+        }
+    }
+}
+
+pm_cafe_tea = {
+    texture = "gfx/interface/icons/production_method_icons/cafe_tea.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_tea_add = 8 goods_output_service_coffee_add = 5 }
+        level_scaled = {
+            building_employment_service_workers_add = 4400
+            building_employment_managers_add = 550
+            building_employment_capitalists_add = 50
+        }
+    }
+    unlocking_technologies = { tea_culture }
+}
+
+pm_dispensary_tobacco = {
+    texture = "gfx/interface/icons/production_method_icons/dispensary_tobacco.dds"
+    building_modifiers = {
+        workforce_scaled = { goods_input_tobacco_add = 8 goods_output_service_tobacco_add = 6 }
+        level_scaled = {
+            building_employment_service_workers_add = 4600
+            building_employment_managers_add = 350
+            building_employment_capitalists_add = 50
+        }
+    }
+}

--- a/localization/english/buildings_l_english.yml
+++ b/localization/english/buildings_l_english.yml
@@ -1,0 +1,9 @@
+l_english:
+ building_bar:0 "Bar"
+ building_bar_lens_option:0 "Expand $building_bar$"
+ building_restaurant:0 "Restaurant"
+ building_restaurant_lens_option:0 "Expand $building_restaurant$"
+ building_cafe:0 "Café"
+ building_cafe_lens_option:0 "Expand $building_cafe$"
+ building_dispensary:0 "Dispensary"
+ building_dispensary_lens_option:0 "Expand $building_dispensary$"

--- a/localization/english/goods_l_english.yml
+++ b/localization/english/goods_l_english.yml
@@ -1,0 +1,7 @@
+l_english:
+ beer:0 "Beer"
+ service_beer:0 "Beer Service"
+ service_liquor:0 "Spirit Service"
+ service_food:0 "Prepared Meals"
+ service_coffee:0 "Coffee Service"
+ service_tobacco:0 "Tobacco Service"

--- a/localization/english/pop_types_l_english.yml
+++ b/localization/english/pop_types_l_english.yml
@@ -1,0 +1,3 @@
+l_english:
+ service_worker:0 "Service Worker"
+ manager:0 "Manager"

--- a/localization/english/production_methods_l_english.yml
+++ b/localization/english/production_methods_l_english.yml
@@ -1,0 +1,12 @@
+l_english:
+ pm_bar_beer:0 "Beer Hall"
+ pm_bar_liquor:0 "Spirit Bar"
+ pm_restaurant_meat:0 "Bistro"
+ pm_restaurant_groceries:0 "Grocers' Kitchen"
+ pm_cafe_coffee:0 "Coffeehouse"
+ pm_cafe_tea:0 "Tea Room"
+ pm_dispensary_tobacco:0 "Tobacconist"
+ pmg_base_building_bar:1 "$pm_base$"
+ pmg_base_building_restaurant:1 "$pm_base$"
+ pmg_base_building_cafe:1 "$pm_base$"
+ pmg_base_building_dispensary:1 "$pm_base$"


### PR DESCRIPTION
## Summary
- fix service goods categories (use `luxury`)
- add employment numbers for Bar, Restaurant, Café and Dispensary production methods

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef39cf4b0832eb38539d000773134