### PR TITLE
Update goods to entertainment categories

### DIFF
--- a/Goals.md
+++ b/Goals.md
@@ -38,11 +38,9 @@
 | Tag               | Category     | Consumed by POP need         | Supplied by          | Notes                                      |
 | ----------------- | ------------ | ---------------------------- | -------------------- | ------------------------------------------ |
 | `beer`            | **consumer** | Luxury Drinks (poor/avg)     | Breweries (existing) | Split from Liquor; base price 20.          |
-| `service_beer`    | **service**  | Luxury Drinks (¾ weight)     | **Bar** (Beer PM)    | Counts as 1.25 × *Beer* when meeting need. |
-| `service_liquor`  | service      | Luxury Drinks (full weight)  | Bar (Liquor PM)      | Premium; yields +Prestige in rich states.  |
 | `service_food`    | service      | Staple Food (rich weight)    | **Restaurant**       | Uses Meat or Groceries.                    |
-| `service_coffee`  | service      | Luxury Drinks (middle-class) | **Café**             | Requires Coffee input.                     |
-| `service_tobacco` | service      | Luxury Drinks (poor/middle)  | **Dispensary**       | Requires Tobacco input.                    |
+| `service_entertainment_low`  | service      | Luxury Drinks (basic venues) | Bars & Cafés        | Replaces beer/coffee services.             |
+| `service_entertainment_high` | service      | Luxury Drinks (premium)      | Bars & Dispensaries | Replaces liquor/tobacco services.          |
 
 ### 4.2  New POP Types
 

--- a/common/goods/00_service_goods.txt
+++ b/common/goods/00_service_goods.txt
@@ -6,33 +6,21 @@ beer = {
     obsession_chance = 1.0
     prestige_factor = 4
 }
-service_beer = {
-    texture = "gfx/interface/icons/goods_icons/service_beer.dds"
-    cost = 25
+service_entertainment_low = {
+    texture = "gfx/interface/icons/goods_icons/service_entertainment_low.dds"
+    cost = 30
     category = luxury
     local = yes
 }
-service_liquor = {
-    texture = "gfx/interface/icons/goods_icons/service_liquor.dds"
-    cost = 30
+service_entertainment_high = {
+    texture = "gfx/interface/icons/goods_icons/service_entertainment_high.dds"
+    cost = 35
     category = luxury
     local = yes
 }
 service_food = {
     texture = "gfx/interface/icons/goods_icons/service_food.dds"
     cost = 25
-    category = luxury
-    local = yes
-}
-service_coffee = {
-    texture = "gfx/interface/icons/goods_icons/service_coffee.dds"
-    cost = 35
-    category = luxury
-    local = yes
-}
-service_tobacco = {
-    texture = "gfx/interface/icons/goods_icons/service_tobacco.dds"
-    cost = 30
     category = luxury
     local = yes
 }

--- a/common/production_methods/99_hospitality.txt
+++ b/common/production_methods/99_hospitality.txt
@@ -1,7 +1,7 @@
 pm_bar_beer = {
     texture = "gfx/interface/icons/production_method_icons/bar_beer.dds"
     building_modifiers = {
-        workforce_scaled = { goods_input_beer_add = 10 goods_output_service_beer_add = 8 }
+        workforce_scaled = { goods_input_beer_add = 10 goods_output_service_entertainment_low_add = 8 }
         level_scaled = {
             building_employment_service_workers_add = 4500
             building_employment_managers_add = 450
@@ -13,7 +13,7 @@ pm_bar_beer = {
 pm_bar_liquor = {
     texture = "gfx/interface/icons/production_method_icons/bar_liquor.dds"
     building_modifiers = {
-        workforce_scaled = { goods_input_liquor_add = 10 goods_output_service_liquor_add = 8 }
+        workforce_scaled = { goods_input_liquor_add = 10 goods_output_service_entertainment_high_add = 8 }
         level_scaled = {
             building_employment_service_workers_add = 4500
             building_employment_managers_add = 450
@@ -50,7 +50,7 @@ pm_restaurant_groceries = {
 pm_cafe_coffee = {
     texture = "gfx/interface/icons/production_method_icons/cafe_coffee.dds"
     building_modifiers = {
-        workforce_scaled = { goods_input_coffee_add = 8 goods_output_service_coffee_add = 6 }
+        workforce_scaled = { goods_input_coffee_add = 8 goods_output_service_entertainment_low_add = 6 }
         level_scaled = {
             building_employment_service_workers_add = 4400
             building_employment_managers_add = 550
@@ -62,7 +62,7 @@ pm_cafe_coffee = {
 pm_cafe_tea = {
     texture = "gfx/interface/icons/production_method_icons/cafe_tea.dds"
     building_modifiers = {
-        workforce_scaled = { goods_input_tea_add = 8 goods_output_service_coffee_add = 5 }
+        workforce_scaled = { goods_input_tea_add = 8 goods_output_service_entertainment_low_add = 5 }
         level_scaled = {
             building_employment_service_workers_add = 4400
             building_employment_managers_add = 550
@@ -75,7 +75,7 @@ pm_cafe_tea = {
 pm_dispensary_tobacco = {
     texture = "gfx/interface/icons/production_method_icons/dispensary_tobacco.dds"
     building_modifiers = {
-        workforce_scaled = { goods_input_tobacco_add = 8 goods_output_service_tobacco_add = 6 }
+        workforce_scaled = { goods_input_tobacco_add = 8 goods_output_service_entertainment_high_add = 6 }
         level_scaled = {
             building_employment_service_workers_add = 4600
             building_employment_managers_add = 350

--- a/localization/english/goods_l_english.yml
+++ b/localization/english/goods_l_english.yml
@@ -1,7 +1,5 @@
 l_english:
  beer:0 "Beer"
- service_beer:0 "Beer Service"
- service_liquor:0 "Spirit Service"
+ service_entertainment_low:0 "Basic Entertainment"
+ service_entertainment_high:0 "Premium Entertainment"
  service_food:0 "Prepared Meals"
- service_coffee:0 "Coffee Service"
- service_tobacco:0 "Tobacco Service"

--- a/mod/common/goods/10_service_goods.txt
+++ b/mod/common/goods/10_service_goods.txt
@@ -11,17 +11,17 @@ beer = {
     convoy_cost_multiplier = 0.75
 }
 
-service_beer = {
-    texture = "gfx/interface/icons/goods_icons/service_beer.dds"
+service_entertainment_low = {
+    texture = "gfx/interface/icons/goods_icons/service_entertainment_low.dds"
     cost = 30
     category = service
     local = yes
     consumption_tax_cost = 200
 }
 
-service_liquor = {
-    texture = "gfx/interface/icons/goods_icons/service_liquor.dds"
-    cost = 30
+service_entertainment_high = {
+    texture = "gfx/interface/icons/goods_icons/service_entertainment_high.dds"
+    cost = 35
     category = service
     local = yes
     consumption_tax_cost = 200
@@ -35,18 +35,3 @@ service_food = {
     consumption_tax_cost = 200
 }
 
-service_coffee = {
-    texture = "gfx/interface/icons/goods_icons/service_coffee.dds"
-    cost = 30
-    category = service
-    local = yes
-    consumption_tax_cost = 200
-}
-
-service_tobacco = {
-    texture = "gfx/interface/icons/goods_icons/service_tobacco.dds"
-    cost = 30
-    category = service
-    local = yes
-    consumption_tax_cost = 200
-}

--- a/mod/localization/english/goods_l_english.yml
+++ b/mod/localization/english/goods_l_english.yml
@@ -1,7 +1,5 @@
 l_english:
  beer:0 "Beer"
- service_beer:0 "Beer Service"
- service_liquor:0 "Liquor Service"
+ service_entertainment_low:0 "Basic Entertainment"
+ service_entertainment_high:0 "Premium Entertainment"
  service_food:0 "Prepared Meals"
- service_coffee:0 "Coffee Service"
- service_tobacco:0 "Tobacco Service"


### PR DESCRIPTION
## Summary
- redefine service goods as new entertainment tiers
- adjust PM outputs for bars, cafés and dispensaries
- update English localization for new goods
- revise goods table in project goals

## Testing
- `No tests present`


------
https://chatgpt.com/codex/tasks/task_e_686f313a485c832e9e4cf9963b4eb2e1