### PR TITLE
Add mixed bar production method

### DIFF
--- a/common/production_method_groups/99_hospitality.txt
+++ b/common/production_method_groups/99_hospitality.txt
@@ -3,6 +3,7 @@ pmg_base_building_bar = {
     production_methods = {
         pm_bar_beer
         pm_bar_liquor
+        pm_bar_mixed
     }
 }
 

--- a/common/production_methods/99_hospitality.txt
+++ b/common/production_methods/99_hospitality.txt
@@ -22,6 +22,23 @@ pm_bar_liquor = {
     }
 }
 
+pm_bar_mixed = {
+    texture = "gfx/interface/icons/production_method_icons/bar_mixed.dds"
+    building_modifiers = {
+        workforce_scaled = {
+            goods_input_beer_add = 5
+            goods_input_liquor_add = 5
+            goods_output_service_beer_add = 4
+            goods_output_service_liquor_add = 4
+        }
+        level_scaled = {
+            building_employment_service_workers_add = 4500
+            building_employment_managers_add = 450
+            building_employment_capitalists_add = 50
+        }
+    }
+}
+
 pm_restaurant_meat = {
     texture = "gfx/interface/icons/production_method_icons/restaurant_meat.dds"
     building_modifiers = {

--- a/localization/english/production_methods_l_english.yml
+++ b/localization/english/production_methods_l_english.yml
@@ -1,6 +1,7 @@
 l_english:
  pm_bar_beer:0 "Beer Hall"
  pm_bar_liquor:0 "Spirit Bar"
+ pm_bar_mixed:0 "Mixed Bar"
  pm_restaurant_meat:0 "Bistro"
  pm_restaurant_groceries:0 "Grocers' Kitchen"
  pm_cafe_coffee:0 "Coffeehouse"


### PR DESCRIPTION
## Summary
- add `pm_bar_mixed` to hospitality production methods
- allow bars to pick Mixed Bar production method
- localize Mixed Bar

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f3134a7d0832eb4f4ce1b367f29ca