### PR TITLE
Fix duplicate bar prohibition entries

### DIFF
--- a/common/production_method_groups/99_hospitality.txt
+++ b/common/production_method_groups/99_hospitality.txt
@@ -5,7 +5,6 @@ pmg_base_building_bar = {
         pm_bar_liquor
         pm_bar_prohibition
         pm_bar_mixed
-        pm_bar_prohibition
     }
 }
 

--- a/localization/english/ir_production_methods_l_english.yml
+++ b/localization/english/ir_production_methods_l_english.yml
@@ -3,7 +3,6 @@ l_english:
  pm_bar_liquor:0 "Spirit Bar"
  pm_bar_prohibition:0 "Prohibition"
  pm_bar_mixed:0 "Mixed Bar"
- pm_bar_prohibition:0 "Prohibition"
  pm_restaurant_meat:0 "Bistro"
  pm_restaurant_groceries:0 "Grocers' Kitchen"
  pm_cafe_coffee:0 "Coffeehouse"


### PR DESCRIPTION
## Summary
- remove duplicated `pm_bar_prohibition` localization entry
- deduplicate `pm_bar_prohibition` in bar production method group

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f4bc4e28c832ebcbfa5721466a0d0